### PR TITLE
add missing dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,11 @@
         "output"
     ],
     "dependencies": {
-        "purescript-prelude": "^4.0.0"
+        "purescript-prelude": "^4.0.0",
+        "purescript-record": "^1.0.0",
+        "purescript-tuples": "^5.0.0",
+        "purescript-integers": "^4.0.0",
+        "purescript-enums": "^4.0.0"
     },
     "devDependencies": {
         "purescript-psci-support": "^4.0.0",


### PR DESCRIPTION
missing dependencies prevent this library from working when installed with `bower i -p` in the library and in downstream projects.