### PR TITLE
Remove unused kind, RowList

### DIFF
--- a/src/Data/Hashable.purs
+++ b/src/Data/Hashable.purs
@@ -22,7 +22,7 @@ import Data.List (List)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Prim.Row as Row
-import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
+import Prim.RowList (class RowToList, Cons, Nil)
 import Record (get)
 import Type.Data.RowList (RLProxy(..))
 import Type.Prelude (class IsSymbol, SProxy(..))


### PR DESCRIPTION
This part caused a warning below:

```
Compiling Data.HashSet
Warning found:
in module Data.Hashable
at .spago/unordered-collections/v1.8.2/src/Data/Hashable.purs:25:1 - 25:63 (line 25, column 1 - line 25, column 63)

  The import of module Prim.RowList contains the following unused references:

    RowList

  It could be replaced with:

    import Prim.RowList (class RowToList, Cons, Nil)
```