### PR TITLE
Call function with value present in the map

### DIFF
--- a/src/Data/HashMap.purs
+++ b/src/Data/HashMap.purs
@@ -317,7 +317,7 @@ update f = alter (_ >>= f)
 -- | and the new value, especially if you find yourself writing
 -- | `upsert (f v) k v`, consider using `insertWith` instead.
 upsert :: forall k v. Hashable k => (v -> v) -> k -> v -> HashMap k v -> HashMap k v
-upsert f = insertWith (\_ v -> f v)
+upsert f = insertWith (\v _ -> f v)
 
 -- | Returns the number of key-value pairs in a map.
 -- |


### PR DESCRIPTION
Upsert is not using the value that is already present in the map:

```purs
> import Data.HashMap
> singleton 'x' 10 # upsert (_ + 1) 'x' 1
(fromArray [(Tuple 'x' 2)])
```

I believe the expected behavior is:
```purs
> upsert' f = insertWith \v _ -> f v
> singleton 'x' 10 # upsert' (_ + 1) 'x' 1
(fromArray [(Tuple 'x' 11)])
```