### PR TITLE
Add `any` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.purs*
 /.psa*
 test-bundle.js
+.spago

--- a/src/Data/HashMap.js
+++ b/src/Data/HashMap.js
@@ -477,7 +477,7 @@ MapNode.prototype.itraverse = function (pure, apply, f) {
     return m;
 }
 
-MapNode.prototype.any = function (predicate, level = 0) {
+MapNode.prototype.any = function (predicate) {
   for (var i = 1; i < popCount(this.datamap) * 2; i = i + 2) {
     var v = this.content[i];
 
@@ -489,7 +489,7 @@ MapNode.prototype.any = function (predicate, level = 0) {
   i--;
 
   for (; i < this.content.length; i++) {
-    if (this.content[i].any(predicate, level + 1)) {
+    if (this.content[i].any(predicate)) {
       return true;
     }
   }

--- a/src/Data/HashMap.js
+++ b/src/Data/HashMap.js
@@ -477,6 +477,37 @@ MapNode.prototype.itraverse = function (pure, apply, f) {
     return m;
 }
 
+MapNode.prototype.any = function (predicate, shift) {
+  var dataMap = this.datamap;
+  var nodeMap = this.nodemap;
+
+  while (dataMap !== 0) {
+      var bit = lowestBit(dataMap);
+      var dataIndex = index(this.datamap, bit);
+      var value = this.content[dataIndex * 2 + 1];
+
+      if (predicate(value)) {
+          return true;
+      }
+
+      dataMap &= ~bit;
+  }
+
+  while (nodeMap !== 0) {
+      var bit = lowestBit(nodeMap);
+      var nodeIndex = index(this.nodemap, bit);
+      var subNode = this.content[this.content.length - nodeIndex - 1];
+
+      if (subNode.any(predicate, shift + 5)) {
+          return true;
+      }
+
+      nodeMap &= ~bit;
+  }
+
+  return false;
+};
+
 /** @constructor */
 function Collision(keys, values) {
     this.keys = keys;
@@ -916,4 +947,10 @@ export function nubHashPurs(Nothing, Just, eq, hash) {
         }
         return r;
     };
+};
+
+export function anyPurs(pred) {
+  return function (m) {
+      return m.any(pred, 0);
+  };
 };

--- a/src/Data/HashMap.js
+++ b/src/Data/HashMap.js
@@ -949,6 +949,6 @@ export function nubHashPurs(Nothing, Just, eq, hash) {
 
 export function anyPurs(pred) {
   return function (m) {
-      return m.any(pred, 0);
+      return m.any(pred);
   };
 };

--- a/src/Data/HashMap.js
+++ b/src/Data/HashMap.js
@@ -477,32 +477,21 @@ MapNode.prototype.itraverse = function (pure, apply, f) {
     return m;
 }
 
-MapNode.prototype.any = function (predicate, shift) {
-  var dataMap = this.datamap;
-  var nodeMap = this.nodemap;
+MapNode.prototype.any = function (predicate, level = 0) {
+  for (var i = 1; i < popCount(this.datamap) * 2; i = i + 2) {
+    var v = this.content[i];
 
-  while (dataMap !== 0) {
-      var bit = lowestBit(dataMap);
-      var dataIndex = index(this.datamap, bit);
-      var value = this.content[dataIndex * 2 + 1];
-
-      if (predicate(value)) {
-          return true;
-      }
-
-      dataMap &= ~bit;
+    if (predicate(v)) {
+        return true;
+    }
   }
 
-  while (nodeMap !== 0) {
-      var bit = lowestBit(nodeMap);
-      var nodeIndex = index(this.nodemap, bit);
-      var subNode = this.content[this.content.length - nodeIndex - 1];
+  i--;
 
-      if (subNode.any(predicate, shift + 5)) {
-          return true;
-      }
-
-      nodeMap &= ~bit;
+  for (; i < this.content.length; i++) {
+    if (this.content[i].any(predicate, level + 1)) {
+      return true;
+    }
   }
 
   return false;
@@ -709,6 +698,15 @@ Collision.prototype.filterWithKey = function collisionFilterWithKey(f) {
     if (keys.length === 1) return new MapNode(1, 0, [keys[0], values[0]]);
     return new Collision(keys, values);
 }
+
+Collision.prototype.any = function (predicate) {
+  for (var i = 0; i < this.keys.length; i++) {
+    if (predicate(this.values[i])) {
+      return true;
+    }
+  }
+  return false;
+};
 
 function mask(keyHash, shift) {
     return 1 << ((keyHash >>> shift) & 31);

--- a/src/Data/HashMap.purs
+++ b/src/Data/HashMap.purs
@@ -414,6 +414,6 @@ foreign import anyPurs :: forall k v. (v -> Boolean) -> HashMap k v -> Boolean
 
 -- | Returns true if at least one HashMap element satisfies the given predicate, iterating the HashMap only as necessary and stopping as soon as the predicate yields true.
 -- |
--- | Use this function instead of `Foldable.any`` for more performance.
+-- | Use this function instead of `Foldable.any` for more performance.
 any :: forall k v. (v -> Boolean) -> HashMap k v -> Boolean
 any = anyPurs

--- a/src/Data/HashMap.purs
+++ b/src/Data/HashMap.purs
@@ -46,7 +46,9 @@ module Data.HashMap (
 
   nubHash,
 
-  debugShow
+  debugShow,
+
+  any
   ) where
 
 import Prelude
@@ -407,3 +409,8 @@ nubHash :: forall a. Hashable a => Array a -> Array a
 nubHash = runFn4 nubHashPurs Nothing Just (==) hash
 
 foreign import nubHashPurs :: forall a. Fn4 (forall x. Maybe x) (forall x. x -> Maybe x) (a -> a -> Boolean) (a -> Int) (Array a -> Array a)
+
+foreign import anyPurs :: forall k v. (v -> Boolean) -> HashMap k v -> Boolean
+
+any :: forall k v. (v -> Boolean) -> HashMap k v -> Boolean
+any = anyPurs

--- a/src/Data/HashMap.purs
+++ b/src/Data/HashMap.purs
@@ -412,5 +412,8 @@ foreign import nubHashPurs :: forall a. Fn4 (forall x. Maybe x) (forall x. x -> 
 
 foreign import anyPurs :: forall k v. (v -> Boolean) -> HashMap k v -> Boolean
 
+-- | Returns true if at least one HashMap element satisfies the given predicate, iterating the HashMap only as necessary and stopping as soon as the predicate yields true.
+-- |
+-- | Use this function instead of `Foldable.any`` for more performance.
 any :: forall k v. (v -> Boolean) -> HashMap k v -> Boolean
 any = anyPurs

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -437,6 +437,19 @@ main = do
       Just false -> HM.lookup k mc === HM.lookup k my
       Nothing -> false === HM.member k my
 
+  log "any"
+  quickCheck' 10000 $ \(a :: Array (Tuple Int Int)) ->
+    let hm = HM.fromFoldable a
+        xs = HM.toArrayBy Tuple hm
+    in  (not (HM.any (\_ -> true) HM.empty)) &&
+        case A.head xs of
+          Nothing -> true
+          Just h  -> case A.last xs of
+            Nothing -> true
+            Just l  -> HM.any (\x -> x == snd h) hm
+                    && HM.any (\x -> x == snd l) hm
+                    && (not (HM.any (\_ -> false) hm))
+
   log "Done."
 
 t54 :: Boolean

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,7 +9,7 @@ import Prelude
 import Data.Array as A
 import Data.Array as Array
 import Data.Array.NonEmpty (fromNonEmpty)
-import Data.Foldable (all, foldMap, foldl, foldr)
+import Data.Foldable (all, foldMap, foldl, foldr, any)
 import Data.FoldableWithIndex (allWithIndex, foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.HashMap (HashMap)
 import Data.HashMap as HM

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -450,6 +450,13 @@ main = do
                     && HM.any (\x -> x == snd l) hm
                     && (not (HM.any (\_ -> false) hm))
 
+  log "any agrees with Foldable any"
+  quickCheck' 10000 $ \(a :: Array (Tuple CollidingInt Int)) (f :: Int -> Boolean) ->
+    let m = HM.fromArray a
+        f' (Tuple _ v) = f v
+    -- use array instance, so we still test something useful if any ever becomes a method on Foldable
+    in  any f' a === HM.any f m
+
   log "Done."
 
 t54 :: Boolean


### PR DESCRIPTION
Hashmap implements Foldable.any but Foldable can not short-ciruit. For big hashmaps this should be faster if the value is match is found early.

I also had an alternative implementation but i think it's a bit slower (quick n dirty benchmark)

```javascript
MapNode.prototype.any = function(pred, shift) {
  var skipmap = this.datamap | this.nodemap;
  while (skipmap !== 0) {
      var bit = lowestBit(skipmap);
      skipmap &= ~bit;

      if ((this.datamap & bit) !== 0) {
          var dataIndex = index(this.datamap, bit);
          if (pred(this.content[dataIndex * 2 + 1]))
              return true;
      } else {
          var nodeIndex = index(this.nodemap, bit);
          if (this.content[this.content.length - nodeIndex - 1].any(pred, shift + 5))
              return true;
      }
  }
  return false;
}
```